### PR TITLE
Enable error checking by default

### DIFF
--- a/include/occaDefines.hpp
+++ b/include/occaDefines.hpp
@@ -4,7 +4,7 @@
 #include "ocl_preprocessor.hpp"
 
 //---[ Checks and Info ]----------------
-#if OCCA_DEBUG_ENABLED
+#if OCCA_CHECK_ENABLED
 #  define OCCA_CHECK2( _expr , file , line , func )                     \
   do {                                                                  \
     uintptr_t expr = (_expr);                                              \
@@ -214,7 +214,7 @@
 
 
 //---[ OpenCL ]-------------------------
-#if OCCA_DEBUG_ENABLED
+#if OCCA_CHECK_ENABLED
 ;
 #  define OCCA_CL_CHECK( _str , _statement ) OCCA_CL_CHECK2( _str , _statement , __FILE__ , __LINE__ )
 #  define OCCA_CL_CHECK2( _str , _statement , file , line )             \
@@ -273,7 +273,7 @@
 
 
 //---[ CUDA ]---------------------------
-#if OCCA_DEBUG_ENABLED
+#if OCCA_CHECK_ENABLED
 #  define OCCA_CUDA_CHECK( _str , _statement ) OCCA_CUDA_CHECK2( _str , _statement , __FILE__ , __LINE__ )
 #  define OCCA_CUDA_CHECK2( _str , _statement , file , line )           \
   do {                                                                  \
@@ -318,7 +318,7 @@
 
 
 //---[ COI ]----------------------------
-#if OCCA_DEBUG_ENABLED
+#if OCCA_CHECK_ENABLED
 #  define OCCA_COI_CHECK( _str , _statement ) OCCA_COI_CHECK2( _str , _statement , __FILE__ , __LINE__ )
 #  define OCCA_COI_CHECK2( _str , _statement , file , line )            \
   do {                                                                  \

--- a/scripts/makefile
+++ b/scripts/makefile
@@ -7,6 +7,7 @@ iPath = include
 
 #---[ Default Variables ]-------------------------
 Debug_Enabled  = 0
+Check_Enabled  = 1
 
 icpc_Enabled   = 0
 OpenGL_Enabled = 0
@@ -167,6 +168,11 @@ else
 	flags +=          -DOCCA_OPENMP_ENABLED=0
 endif
 
+ifeq ($(Check_Enabled), 1)
+	flags += -DOCCA_CHECK_ENABLED=1
+else
+	flags += -DOCCA_CHECK_ENABLED=0
+endif
 
 ifeq ($(Pthreads_Enabled), 1)
 	flags += -DOCCA_PTHREADS_ENABLED=1


### PR DESCRIPTION
I ran into an issue this morning where I was asking for a kernel that didn't exist and OCCA quietly gave me a noop kernel.  I believe this is a bad default behavior.  This change turns on error checking in the default build instead of only in debug builds.
