### PR TITLE
Initial travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: cpp
+compiler:
+  - gcc
+env:
+  - OMP_NUM_THREADS=4 CXX=g++-4.8 FC=gfortran-4.8 OCCA_PTHREADS_ENABLED=1 OCCA_OPENMP_ENABLED=1 OCCA_OPENCL_ENABLED=1 OCCA_CUDA_ENABLED=0 OCCA_COI_ENABLED=0 OCCA_OCCA_FORTRAN_ENABLED=1
+before_install:
+  # g++4.8.1
+  - if [ "$CXX" == "g++" ]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; fi
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq fglrx=2:8.960-0ubuntu1 opencl-headers gcc-4.8 g++-4.8 gfortran-4.8
+script:
+  - make
+  - cd examples/addVectors && make
+  - LD_LIBRARY_PATH=../../lib:$LD_LIBRARY_PATH ./main
+# - LD_LIBRARY_PATH=../../lib:$LD_LIBRARY_PATH ./main_c
+  - LD_LIBRARY_PATH=../../lib:$LD_LIBRARY_PATH ./main_f90


### PR DESCRIPTION
This adds support for continuous integration builds with Travis CI.  To get this fully working Dr. Warburton will need to log into https://travis-ci.org and enabling Travis CI to build tcew/OCCA2.  You can see an example of it working here

  https://travis-ci.org/lcw/OCCA2

I disabled the pthreads example (`main_c` in addVectors) because it seems to hang.  It also hangs on my local system.
